### PR TITLE
Migrate deploy from AWS/Node server to Cloudflare Workers

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -2,7 +2,7 @@ name: Deploy to Cloudflare Workers
 
 on:
   push:
-    branches: [ cloudflare-workers-migration ]
+    branches: [ master ]
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,34 @@
+name: Deploy to Cloudflare Workers
+
+on:
+  push:
+    branches: [ cloudflare-workers-migration ]
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+
+    - name: Set up Docker Buildx
+      uses: docker/setup-buildx-action@v3
+
+    - name: Build static assets via Docker
+      # The build uses Node 9 / Webpack 2 (Angular 4 era), so we run it
+      # inside the project's Dockerfile to avoid dependency issues on
+      # modern Node. The `release` stage exports the built dist/ as a tar.
+      run: |
+        docker build -t solar-system . --output type=tar,dest=dist.tar --target release
+        rm -rf dist
+        tar -xf dist.tar
+        rm dist.tar
+
+    - name: Deploy to Cloudflare Workers
+      uses: cloudflare/wrangler-action@v3
+      with:
+        apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+        accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        command: deploy

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,6 +26,12 @@ jobs:
         tar -xf dist.tar
         rm dist.tar
 
+    - name: Install Wrangler
+      # Install globally so wrangler-action skips its own install step.
+      # If it tried to install locally it would run `npm i` against this
+      # project's package.json, which has unresolvable Angular 4 peer deps.
+      run: npm install -g wrangler@latest
+
     - name: Deploy to Cloudflare Workers
       uses: cloudflare/wrangler-action@v3
       with:

--- a/README.md
+++ b/README.md
@@ -11,3 +11,17 @@ docker build -t rjmarques/solar-system . --output type=tar,dest=dist.tar --targe
 
 tar -xf dist.tar
 ```
+
+# Deploying to Cloudflare Workers
+
+The site is hosted on Cloudflare Workers using [Static Assets](https://developers.cloudflare.com/workers/static-assets/).
+Configuration lives in `wrangler.toml`.
+
+Deploys are automated via GitHub Actions (`.github/workflows/deploy.yml`):
+every push to `master` triggers a Docker build of the static assets and then
+publishes them to Cloudflare using [`cloudflare/wrangler-action`](https://github.com/cloudflare/wrangler-action).
+
+Required GitHub repository secrets:
+
+- `CLOUDFLARE_API_TOKEN` — a Workers-scoped API token
+- `CLOUDFLARE_ACCOUNT_ID` — your Cloudflare account ID

--- a/wrangler.toml
+++ b/wrangler.toml
@@ -1,0 +1,14 @@
+"$schema" = "./node_modules/wrangler/config-schema.json"
+
+name = "solar-system"
+compatibility_date = "2026-06-08"
+
+# Static-only Worker: Cloudflare serves files from ./dist directly.
+# No Worker script (`main`) or assets `binding` is needed because we
+# have no dynamic logic.
+[assets]
+directory = "./dist"
+
+# SPA fallback: any request that doesn't match a file in ./dist
+# will return /index.html so Angular's router can handle it.
+not_found_handling = "single-page-application"


### PR DESCRIPTION
- Add wrangler.toml for Workers Static Assets with SPA fallback
- Add GitHub Actions workflow: Docker build + wrangler-action deploy
- Update README with deploy and secrets documentation

Workflow temporarily targets the cloudflare-workers-migration branch to allow iteration before merging to master.